### PR TITLE
HTML library site files with relative CSS and JS path

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -241,6 +241,23 @@ module.exports = function (grunt) {
 			}
 		},
 
+		// Replace content
+		replace: {
+			dev: {
+				options: {
+					patterns: [
+						{
+							match: /..\/(css|js)/g,
+							replacement: '$1'
+						}
+					]
+				},
+				files: [
+					{expand: true, flatten: true, src: ['dev/*.html'], dest: 'dev/'}
+				]
+			}
+		},
+
 		// HTML miniy
 		htmlmin: {
 			options: {
@@ -318,7 +335,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('dev-js', ['concat', 'jshint']);
 
 	// HTML dev task
-	grunt.registerTask('dev-html', ['processhtml:dev', 'processhtml:dev_modify']);
+	grunt.registerTask('dev-html', ['processhtml:dev', 'processhtml:dev_modify', 'replace:dev']);
 
 	// Copy dist task
 	grunt.registerTask('dist-copy', ['clean:dist', 'copy:dist']);

--- a/dev/html/index.html
+++ b/dev/html/index.html
@@ -8,14 +8,14 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<!-- Main stylesheet -->
-	<link href="css/main.css" rel="stylesheet">
+	<link href="../css/main.css" rel="stylesheet">
 
 	<!-- Head JavaScript -->
-	<script src="js/head.js" type="text/javascript"></script>
+	<script src="../js/head.js" type="text/javascript"></script>
 
 	<!-- SVG icon fallback -->
 	<noscript>
-		<link href="css/icons/icons.fallback.css" rel="stylesheet">
+		<link href="../css/icons/icons.fallback.css" rel="stylesheet">
 	</noscript>
 </head>
 
@@ -27,7 +27,7 @@
 </div>
 
 <!-- Main JavaScript -->
-<script src="js/main.js" type="text/javascript"></script>
+<script src="../js/main.js" type="text/javascript"></script>
 
 <!-- build:remove:dist -->
 <!-- Live reload plugin -->


### PR DESCRIPTION
- allows to check correct CSS and JS file references in IDE
- modifies generated dev/index.css CSS and JS path
- integrated grunt-replace plugin
